### PR TITLE
fix bitbucket pipeline

### DIFF
--- a/_templates/bitbucket-pipelines.yml.template
+++ b/_templates/bitbucket-pipelines.yml.template
@@ -7,4 +7,4 @@ pipelines:
           - apt-get update && apt-get install -y unzip
           - curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
           - composer install
-          - ./vendor/bin/phpcs ./ --standard=./phpcs.config.xml
+          - ./vendor/bin/phpcs --standard=./phpcs.xml.dist


### PR DESCRIPTION
1. The phpcs definition is found in phpcs.xml.dist not phpcs.config.xml
2. the phpcs.xml.dist defines to only go thorugh the `src/` folder, so I removed the definition to search through all files (which would include the vendor files)