### PR TITLE
 composer.json sort-packages config

### DIFF
--- a/_templates/composer.json.template
+++ b/_templates/composer.json.template
@@ -21,6 +21,9 @@
     "require-dev": {
         "inpsyde/php-coding-standards": "@stable"
     },
+    "config": {
+        "sort-packages": true
+    },
     "autoload": {
         "psr-4": {
             "{{namespace_autoload}}": "src/"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "ext-mbstring": "*",
         "brightnucleus/boilerplate": "~0.1"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "brightnucleus-boilerplate": {
             "config-file": "_config/defaults.php",


### PR DESCRIPTION
By adding 
```
"config": {
  "sort-packages": true
},
```
to `composer.json`, "[…] the `require` command keeps packages sorted by name […] when adding a new package" ([`sort-packages`](https://getcomposer.org/doc/06-config.md#sort-packages)).
