### PR TITLE
Verify the package name is not enclosed in quotes

### DIFF
--- a/_config/defaults.php
+++ b/_config/defaults.php
@@ -41,7 +41,7 @@ $placeholders = [
         'name' => 'Package name',
         'description' => 'Human readable package name',
         'validation' => function ($placeholder) {
-            return Validation::validateTrimmed($placeholder);
+            return Validation::validateTrimmed($placeholder) && Validation::validateUnquoted($placeholder);
         },
         'default' => 'Awesome Package',
     ],

--- a/_src/SetupHelper.php
+++ b/_src/SetupHelper.php
@@ -33,9 +33,7 @@ class SetupHelper extends Scripts\SetupHelper
      */
     public static function getUnquoted($string)
     {
-        $string = trim($string,"'");
-        
-        return trim($string, '"');
+        return trim($string,'\'"');
     }
 
     /**

--- a/_src/SetupHelper.php
+++ b/_src/SetupHelper.php
@@ -25,6 +25,20 @@ class SetupHelper extends Scripts\SetupHelper
     }
 
     /**
+     * Remove quotes and/or double-quotes enclosing the string.
+     *
+     * @param string $string String to be sanitized.
+     *
+     * @return string Converted string.
+     */
+    public static function getUnquoted($string)
+    {
+        $string = trim($string,"'");
+        
+        return trim($string, '"');
+    }
+
+    /**
      * Return a valid license abbreviation according to SPDX recommendation
      *
      * @link https://spdx.org/licenses/

--- a/_src/Validation.php
+++ b/_src/Validation.php
@@ -94,4 +94,29 @@ class Validation extends Scripts\Validation
             "Provided namespace is invalid: '{$namespace}'"
         );
     }
+
+
+    /**
+     * Verify that a string has no unnecessary quotes or throw an Exception
+     *
+     * @since 0.1.0
+     *
+     * @param string $string The string to validate.
+     *
+     * @return string The validated string.
+     * @throws Exception\InvalidArgumentException If the string is quoted or double-quoted.
+     */
+    public static function validateUnquoted($string)
+    {
+        if (SetupHelper::getUnquoted($string) === $string) {
+            return $string;
+        }
+
+        throw new Exception\InvalidArgumentException(
+            sprintf(
+                'Provided string "%1$s" has unnecessary quotes or double-quotes.',
+                $string
+            )
+        );
+    }
 }


### PR DESCRIPTION
I started to create my first wordpress plugin using this package.

Since the example strings are enclosed in quotes, I thought they were necessary when using multiple words:
![Input-with-quotes](https://user-images.githubusercontent.com/3101238/84976247-0a041980-b0ed-11ea-9534-0d3051446a7a.png)

The package didn't advise about it and continued to ask for more details.

After that, the installation tasks started and everything was fine. 

I was happy, until it failed (after having me waiting):
![Error-caused-by-name-with-double-quotes](https://user-images.githubusercontent.com/3101238/84976390-5a7b7700-b0ed-11ea-8469-178c649488e4.png)

It was not possible to create that one file because it contains quotes in the filename.

This PR validates and advise from the beginning to prevent this scenario.

This is a screenshot with the result (showing the validation message):
![Result-with-the-added-validation](https://user-images.githubusercontent.com/3101238/84976644-091fb780-b0ee-11ea-9803-7a00de7111e8.png)


