### PR TITLE
Update gpl license

### DIFF
--- a/_config/defaults.php
+++ b/_config/defaults.php
@@ -57,13 +57,13 @@ $placeholders = [
     ],
     'license' => [
         'name' => 'License',
-        'description' => 'License abbreviation [MIT|GPL]',
+        'description' => 'License abbreviation [GPL|MIT]',
         'validation' => function ($placeholder) {
             return SetupHelper::getSPDXLicense(
                 Validation::validateLicenseAbbr($placeholder)
             );
         },
-        'default' => 'MIT',
+        'default' => 'GPL',
     ],
     'type' => [
         'name' => 'Package type',

--- a/_config/defaults.php
+++ b/_config/defaults.php
@@ -41,7 +41,7 @@ $placeholders = [
         'name' => 'Package name',
         'description' => 'Human readable package name',
         'validation' => function ($placeholder) {
-            return Validation::validateTrimmed($placeholder) && Validation::validateUnquoted($placeholder);
+            return Validation::validateTrimmed(Validation::validateUnquoted($placeholder));
         },
         'default' => 'Awesome Package',
     ],

--- a/_src/SetupHelper.php
+++ b/_src/SetupHelper.php
@@ -49,7 +49,7 @@ class SetupHelper extends Scripts\SetupHelper
     {
         $licenses = [
             'mit' => 'MIT',
-            'gpl' => 'GPL-2.0' //GPL-2.0+ is deprecated
+            'gpl' => 'GPL-2.0-or-later'
         ];
 
         $license = strtolower($license);

--- a/_src/Task/SanitizeLicenseFiles.php
+++ b/_src/Task/SanitizeLicenseFiles.php
@@ -26,7 +26,7 @@ class SanitizeLicenseFiles extends Task\AbstractTask
         $license = $this->getConfigKey('Placeholders', 'license')['value'];
         $license_files = [
             'MIT' => 'LICENSE.mit',
-            'GPL-2.0' => 'LICENSE.gpl2',
+            'GPL-2.0-or-later' => 'LICENSE.gpl2',
         ];
 
         if (! isset($license_files[$license])) {


### PR DESCRIPTION
👋
Not sure why the validation fix I just pushed to master shows up in the diff, but it involves an issue where a boolean was returned instead of a string validated twice.

Anyway: this is a shortcut to make sure that 'GPLv2 or later' is used whenever GPL is chosen for the plugin, according to our Inpsyde's internal license policy. As @tzimpel has remarked, the license entry in the plugin header should be formatted differently, which would mean adding logic to the setup steps.

Further development should consider, IMHO:
- adding the formatting logic mentioned above
- adding the license URI in the plugin header
- setting GPLv2.0+ as a default instead of MIT
- adding the plugin boilerplate code as suggested two years ago(!) by @Chrico in #14 (and the plugin-guidelines branch created by @tzimpel)
- adding unit testing, perhaps under a flag (as suggested in the plugin-guidelines branch)
- adding a default asset pipeline using [inpsyde/asset](https://github.com/inpsyde/assets)s and [@symfony/webpack-encore](https://www.npmjs.com/package/@symfony/webpack-encore), also under a flag

